### PR TITLE
A lot of things, Changed template to render from embedded, changed gh…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ build:
 	@echo "Building Taco"
 	@go build -o taco ./cmd/taco
 
+install:
+	@echo "Installing Taco"
+	@go install ./cmd/taco
 lint:
 	@echo "Linting source code"
 	@golangci-lint run

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -3,7 +3,14 @@ package gh
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
 
+	"github.com/b-jonathan/taco/internal/execx"
+	"github.com/b-jonathan/taco/internal/logx"
+	"github.com/b-jonathan/taco/internal/prompt"
 	"github.com/google/go-github/v55/github"
 	"golang.org/x/oauth2"
 )
@@ -35,11 +42,81 @@ func FromContext(ctx context.Context) (*github.Client, error) {
 // HasClient tells whether a client is present.
 func HasClient(ctx context.Context) bool { return ctx.Value(ghClientKey) != nil }
 
-// MustFromContext is optional if you like the panic behavior.
-func MustFromContext(ctx context.Context) *github.Client {
-	c, err := FromContext(ctx)
-	if err != nil {
-		panic(err)
+func EnsureClient(ctx context.Context) (*github.Client, error) {
+	if client, err := FromContext(ctx); err == nil {
+		logx.Infof("Using existing GitHub client from context")
+		return client, nil
 	}
-	return c
+
+	if _, err := exec.LookPath("gh"); err != nil {
+		fmt.Println("GitHub CLI not found on your system.")
+
+		// Detect OS
+		osName := runtime.GOOS
+
+		var installCmd string
+		var installDescription string
+
+		switch osName {
+		case "windows":
+			installCmd = "winget install GitHub.cli"
+			installDescription = "winget install GitHub.cli"
+		case "darwin":
+			installCmd = "brew install gh"
+			installDescription = "brew install gh"
+		case "linux":
+			installCmd = "sudo apt install gh"
+			installDescription = "sudo apt install gh"
+		default:
+			return nil, fmt.Errorf("unsupported OS. Please install GitHub CLI manually")
+		}
+
+		// Ask if user wants auto installation
+		shouldInstall, err := prompt.CreateSurveyConfirm(
+			fmt.Sprintf("GitHub CLI is required. Would you like Taco to install it using %s?", installDescription),
+			prompt.AskOpts{Default: true},
+		)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to confirm installation: %w", err)
+		}
+
+		if shouldInstall {
+			fmt.Println("Installing GitHub CLI...")
+
+			if err := execx.RunCmdLive(ctx, "", installCmd); err != nil {
+				return nil, fmt.Errorf("installation failed. Please install GitHub CLI manually using %s", installDescription)
+			}
+
+			fmt.Println("GitHub CLI installed successfully")
+		} else {
+			return nil, fmt.Errorf("GitHub CLI is required. Install using %s", installDescription)
+		}
+	}
+	if err := execx.RunCmd(ctx, "", "gh auth status"); err != nil {
+		fmt.Println("You are not authenticated with GitHub CLI.")
+		shouldLogin, _ := prompt.CreateSurveyConfirm(
+			"Would you like to authenticate now?",
+			prompt.AskOpts{Default: true},
+		)
+		if shouldLogin {
+			fmt.Println("Starting GitHub authentication...")
+
+			if err := execx.RunCmdLive(ctx, "", "gh auth login"); err != nil {
+				return nil, fmt.Errorf("failed to authenticate with GitHub CLI: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("GitHub authentication is required to proceed")
+		}
+	}
+
+	tokenBytes, err := exec.Command("gh", "auth", "token").Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve GitHub token: %w", err)
+	}
+	token := strings.TrimSpace(string(tokenBytes))
+
+	client := NewClient(ctx, token)
+	client.UserAgent = "taco-cli"
+	return client, nil
 }

--- a/internal/stacks/templates/embed.go
+++ b/internal/stacks/templates/embed.go
@@ -1,0 +1,6 @@
+package templates
+
+import "embed"
+
+//go:embed express/* firebase/* mongodb/* nextjs/*
+var FS embed.FS


### PR DESCRIPTION
… to use gh auth isntead of token, taco now runs from cwd instead of parent

## Summary

Makes Taco a standalone runnable vs one contained inside this repo. Now generates projects in cwd instead of it's parent. Adjust other features to make the above possible



Closes #43 if applicable.

---

## Changes Made

- [ ] Added new stack: `<stack name>`
- [x] Updated existing functionality
- [ ] Improved documentation
- [x] Refactored internal code
- [ ] Fixed a bug

Briefly summarize the major changes:

-  Uses embed so that template path is contained within the binary as opposed to hardcoded to the device.
-  Update Github setup to use gh auth instead of GITHUB_TOKEN from .env as .env's shouldnt be part of the binary that's compiled
- uses CWD for project path instead of CWD's parents

---

## Testing

How was this change tested?

- [ ] `go test ./...` passes locally
- [x] Manual testing done with `taco` CLI
- [x] CI checks pass

Provide details:

```bash
# Example test commands
go test ./...
taco init test-app
